### PR TITLE
ft-delete-user enables admin to delete a user account

### DIFF
--- a/api/services/users/user.js
+++ b/api/services/users/user.js
@@ -88,10 +88,12 @@ const updateUser = async (req, res) => {
 // function that deletes a user
 const deleteUser = async (req, res) => {
     try{
-        let user = await User.findByIdAndRemove(req.params.id)
-        if(user)
-            return error.errorMessage(res, 200, `user is deleted successfully`, true)
-        return error.errorMessage(res, 500, 'something went wrong', false)
+        if (mongoose.Types.ObjectId.isValid(req.params.id)){
+            let user = await User.findByIdAndRemove(req.params.id)
+            if(user)
+                return error.errorMessage(res, 200, `user is deleted successfully`, true)
+        }
+        return error.errorMessage(res, 404, 'use a valid user id', false)
     }catch(err){
         return error.errorMessage(res, 500, err.message, false)
     }

--- a/test/nouser.test.js
+++ b/test/nouser.test.js
@@ -42,4 +42,13 @@ describe('This suit handles tests for users endpoints', () => {
             done()
         })
     })
+
+    it('update user -> invalid user id', done => {
+        chai.request(app).delete('/api/v1/users/sss').set('Accept', 'application/json').end((err, res) => {
+            expect(res.status).to.equal(404)
+            expect(res.body.success).to.equal(false)
+            expect(res.body.message).to.equal('use a valid user id')
+            done()
+        })
+    })
 })

--- a/test/users.test.js
+++ b/test/users.test.js
@@ -171,4 +171,16 @@ describe('This suit handles tests for users endpoints', () => {
             done()
         })
     })
+
+    it('delete user -> correct way', done => {
+        chai.request(app).get('/api/v1/users').set('Accept', 'application/json').end((err, res) => {
+            let userid = res.body.data[0]._id
+            chai.request(app).delete(`/api/v1/users/${userid}`).set('Accept', 'application/json').end((err, res) => {
+                expect(res.status).to.equal(200)
+                expect(res.body.success).to.equal(true)
+                expect(res.body.message).to.equal('user is deleted successfully')
+                done()
+            })
+        })
+    })
 })


### PR DESCRIPTION
  - This feature enables users to delete a user account, especially
  users with reported issues.

**What does this PR do?**
This PR enables the admin to delete a users in the application

**Description of Task to be completed?**
- Admin should be able to delete users in the application.
- Tested users endpoints

**How should this be manually tested?**

- Clone the repo and change directory with `cd` into shopline
- checkout the branch `ft-delete-user`
- Run the commands below to install packages and run the server
         `npm install`
         `npm start`
- Navigate to `delete`: http://localhost:3000/api/v1/users  for `delete-user`

**What are the relevant trello stories?**
- [Delete User](https://trello.com/c/zIgFB5wx)

**Screenshots**
- view all users screenshot
<img width="945" alt="delete-user" src="https://user-images.githubusercontent.com/19649761/67044050-1ede7680-f134-11e9-9122-71a3b4f22544.PNG">
